### PR TITLE
Script setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "itmd362-project1",
+  "name": "project2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,21 @@
+#! /usr/bin/env sh
+
+STASH_NAME="pre-commit-$(date +%s)"
+
+git stash push -q --keep-index --include-untracked --message $STASH_NAME
+
+FAILED_TESTS=0
+trap 'FAILED_TESTS=$((FAILED_TESTS+1))' ERR
+# List all test commands to be run
+
+STASHES=$(git stash list -1 | grep -o $STASH_NAME)
+if [[ $STASHES == $STASH_NAME ]]; then
+  git reset --hard -q && git stash apply --index -q && git stash drop -q
+fi
+
+if ((FAILED_TESTS == 0)); then
+  exit 0 # Proceed with the commit
+else
+  echo "Unable to make commit; fix code and stage fixes with \`git add\`"
+  exit 1 # Halt the commit
+fi

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,18 @@
+#! /usr/bin/env sh
+# Hold onto the root of the repository
+REPO_ROOT=$(git rev-parse --show-toplevel)
+PRE_COMMIT_HOOK=$REPO_ROOT/.git/hooks/pre-commit
+
+# Check to see if the pre-commit symlink exists. If so, unlink it. This will
+# help with any future changes to the pre-commit script's location.
+if [ -L "$PRE_COMMIT_HOOK" ]; then
+  unlink $PRE_COMMIT_HOOK
+fi
+
+# Link the pre-commit hook relative to the `.git/hooks` directory
+# This assumes that you're storing your hooks at $REPO_ROOT/scripts.
+# Adjust the path as necessary.
+ln -s ../../scripts/pre-commit $PRE_COMMIT_HOOK
+
+# Install all dependencies, including development dependencies
+npm install --save-dev


### PR DESCRIPTION
Added script directory with setup and pre-commit shell scripts. We still need to correctly configure backstop to test properly or else none of our commits will be able to be pushed. Once this is completed we can input all linters, backstop, and nightwatch into the pre-commit script. 

For now, ensure you run scripts/setup for all dependencies to be the same. 